### PR TITLE
feat: add variable ways package and dev route

### DIFF
--- a/web-sdk/apps/lines/src/routes/dev/variable-ways.svelte
+++ b/web-sdk/apps/lines/src/routes/dev/variable-ways.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import { VariableWaysGrid } from "@stake/variable-ways";
+</script>
+
+<VariableWaysGrid />

--- a/web-sdk/packages/variable-ways/package.json
+++ b/web-sdk/packages/variable-ways/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@stake/variable-ways",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "svelte": "./src/lib/VariableWaysGrid.svelte",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "echo \"variable-ways: nothing to build\""
+  }
+}

--- a/web-sdk/packages/variable-ways/src/index.ts
+++ b/web-sdk/packages/variable-ways/src/index.ts
@@ -1,0 +1,2 @@
+export { default as VariableWaysGrid } from "./lib/VariableWaysGrid.svelte";
+export * from "./lib/VariableWaysGrid.svelte";

--- a/web-sdk/packages/variable-ways/src/lib/VariableWaysGrid.svelte
+++ b/web-sdk/packages/variable-ways/src/lib/VariableWaysGrid.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  // TODO: implement Variable Ways grid component
+</script>
+
+<div>VariableWaysGrid placeholder</div>


### PR DESCRIPTION
## Summary
- scaffold variable ways component library
- add dev route to render variable ways grid

## Testing
- `pnpm --filter @stake/variable-ways build`
- `pnpm -w build` *(fails: Your tsconfig.json should extend the configuration generated by SvelteKit)*

------
https://chatgpt.com/codex/tasks/task_e_689d038a4878832fb97c8481affc6b94