### PR TITLE
feat: add variable ways package and dev route

### DIFF
--- a/web-sdk/apps/lines/src/routes/dev/variable-ways.svelte
+++ b/web-sdk/apps/lines/src/routes/dev/variable-ways.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { VariableWaysGrid } from "@stake/variable-ways";
+
+  const symbols = ['A', 'K', 'Q', 'J', '10', '9'];
+  let reels: string[][] = [];
+
+  function randomize() {
+    const reelCount = 6;
+    reels = Array.from({ length: reelCount }, () => {
+      const rows = Math.floor(Math.random() * 4) + 3; // 3-6
+      return Array.from({ length: rows }, () => symbols[Math.floor(Math.random() * symbols.length)]);
+    });
+  }
+
+  randomize();
+</script>
+
+<div class="dev">
+  <button on:click={randomize}>Randomize</button>
+  <VariableWaysGrid {reels} />
+</div>
+
+<style>
+  .dev {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+  }
+</style>

--- a/web-sdk/packages/variable-ways/package.json
+++ b/web-sdk/packages/variable-ways/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@stake/variable-ways",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "svelte": "./src/lib/VariableWaysGrid.svelte",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "echo \"variable-ways: nothing to build\""
+  }
+}

--- a/web-sdk/packages/variable-ways/src/index.ts
+++ b/web-sdk/packages/variable-ways/src/index.ts
@@ -1,0 +1,2 @@
+export { default as VariableWaysGrid } from "./lib/VariableWaysGrid.svelte";
+export * from "./lib/VariableWaysGrid.svelte";

--- a/web-sdk/packages/variable-ways/src/lib/VariableWaysGrid.svelte
+++ b/web-sdk/packages/variable-ways/src/lib/VariableWaysGrid.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  export let reels: string[][] = [];
+  export let reelGap: number = 8;
+  export let maxRows: number = 7;
+  export let cellSize: number = 84;
+
+  const symbols = ['A', 'K', 'Q', 'J', '10', '9'];
+
+  function randomReels(count = 6) {
+    return Array.from({ length: count }, () => {
+      const rows = Math.floor(Math.random() * 4) + 3; // 3-6
+      return Array.from({ length: rows }, () => symbols[Math.floor(Math.random() * symbols.length)]);
+    });
+  }
+
+  if (!reels || reels.length === 0) {
+    reels = randomReels();
+  }
+</script>
+
+<div
+  class="grid"
+  style="--cellSize:{cellSize}px; --gap:{reelGap}px; --maxRows:{maxRows}; grid-template-columns:repeat({reels.length}, 1fr);"
+>
+  {#each reels as reel}
+    <div class="reel">
+      {#each reel as symbol}
+        <div class="cell">{symbol}</div>
+      {/each}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .grid {
+    display: grid;
+    column-gap: var(--gap);
+    height: calc(var(--cellSize) * var(--maxRows) + var(--gap) * (var(--maxRows) - 1));
+    padding: var(--gap);
+    background: #f9f9f9;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+  }
+  .reel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+    align-items: center;
+  }
+  .cell {
+    width: var(--cellSize);
+    height: var(--cellSize);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: white;
+    font-family: sans-serif;
+    font-size: 1.25rem;
+    color: #333;
+    transition: background 0.2s;
+  }
+  .cell:hover {
+    background: #f0f0f0;
+  }
+</style>


### PR DESCRIPTION
## Summary
- implement dynamic `VariableWaysGrid` component with default reel generation and CSS-driven layout
- add dev route with randomize button to demo `VariableWaysGrid`

## Testing
- `pnpm --filter @stake/variable-ways build`
- `pnpm -w build` *(fails: command @stake/variable-ways#build no output files; cluster build exited 137)*

------
https://chatgpt.com/codex/tasks/task_e_689d038a4878832fb97c8481affc6b94