### PR TITLE
feat: integrate math-sdk ways evaluation

### DIFF
--- a/web-sdk/apps/lines/src/routes/dev/variable-ways.svelte
+++ b/web-sdk/apps/lines/src/routes/dev/variable-ways.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { VariableWaysGrid, spin, finishEvaluation, spinStore } from "@stake/variable-ways";
+
+  async function handleSpin() {
+    await spin();
+    await finishEvaluation();
+  }
+</script>
+
+<div class="dev">
+  <div class="controls">
+    <button on:click={handleSpin}>Spin</button>
+    <span>State: {$spinStore.state}</span>
+  </div>
+  <VariableWaysGrid reels={$spinStore.reels} />
+  {#if $spinStore.lastWin.totalWin > 0}
+    <div class="wins">
+      <div>Total Win: {$spinStore.lastWin.totalWin}</div>
+      <ul>
+        {#each $spinStore.lastWin.wins as w}
+          <li>{w.symbol} x{w.count} = {w.payout}</li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .dev {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+  }
+
+  .controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+</style>

--- a/web-sdk/apps/lines/src/stories/VariableWaysGrid.stories.svelte
+++ b/web-sdk/apps/lines/src/stories/VariableWaysGrid.stories.svelte
@@ -1,0 +1,118 @@
+<script lang="ts" module>
+import { defineMeta } from '@storybook/addon-svelte-csf';
+import { VariableWaysGrid } from '@stake/variable-ways';
+
+const { Story } = defineMeta({
+    title: 'VariableWays/VariableWaysGrid',
+    component: VariableWaysGrid,
+    parameters: {
+        docs: { description: { component: 'Spin uses Math SDK ways evaluation for accurate results.' } }
+    },
+    args: {
+        reelCount: 6,
+        minRows: 3,
+        maxRows: 6,
+        cellSize: 80,
+        gap: 8,
+    },
+    argTypes: {
+        reelCount: { control: { type: 'number', min: 3, max: 8 } },
+        minRows: { control: { type: 'number', min: 2, max: 7 } },
+        maxRows: { control: { type: 'number', min: 3, max: 9 } },
+        cellSize: { control: { type: 'number', min: 48, max: 128 } },
+        gap: { control: { type: 'number', min: 0, max: 16 } },
+    },
+});
+</script>
+
+<script lang="ts">
+import { onMount } from 'svelte';
+import { VariableWaysGrid, spin, finishEvaluation, spinStore } from '@stake/variable-ways';
+
+const SYMBOLS = ['A', 'K', 'Q', 'J', '10', '9'];
+
+export let reelCount: number;
+export let minRows: number;
+export let maxRows: number;
+export let cellSize: number;
+export let gap: number;
+
+function generateReels(reelsCount: number, min: number, max: number): string[][] {
+    return Array.from({ length: reelsCount }, () => {
+        const rows = Math.floor(Math.random() * (max - min + 1)) + min;
+        return Array.from({ length: rows }, () => SYMBOLS[Math.floor(Math.random() * SYMBOLS.length)]);
+    });
+}
+
+function randomize(args = { reelCount, minRows, maxRows }) {
+    const r = generateReels(args.reelCount, args.minRows, args.maxRows);
+    spinStore.update((s) => ({ ...s, reels: r }));
+}
+
+async function handleSpin() {
+    await spin();
+    await finishEvaluation();
+}
+
+onMount(() => {
+    randomize();
+});
+</script>
+
+{#snippet template(args)}
+<div style="display:flex; flex-direction:column; gap:8px; padding:16px;">
+    <div style="display:flex; gap:8px; align-items:center;">
+        <button on:click={() => randomize(args)}>Randomize</button>
+        <button on:click={handleSpin}>Spin</button>
+        {#if $spinStore.lastWin.totalWin > 0}
+            <span>Win: {$spinStore.lastWin.totalWin}</span>
+        {/if}
+    </div>
+    <VariableWaysGrid reels={$spinStore.reels} cellSize={args.cellSize} reelGap={args.gap} />
+</div>
+{/snippet}
+
+<Story name="Playground" {template} />
+
+<Story name="SixReelsVariableHeights">
+    {#snippet template()}
+        {@const reels = generateReels(6, 3, 6)}
+        <div style="padding:16px;">
+            <VariableWaysGrid {reels} cellSize={80} reelGap={8} />
+        </div>
+    {/snippet}
+</Story>
+
+<Story name="AllMinHeights">
+    {#snippet template()}
+        {@const reels = generateReels(6, 3, 3)}
+        <div style="padding:16px;">
+            <VariableWaysGrid {reels} cellSize={80} reelGap={8} />
+        </div>
+    {/snippet}
+</Story>
+
+<Story name="AllMaxHeights">
+    {#snippet template()}
+        {@const reels = generateReels(6, 6, 6)}
+        <div style="padding:16px;">
+            <VariableWaysGrid {reels} cellSize={80} reelGap={8} />
+        </div>
+    {/snippet}
+</Story>
+
+<Story name="DeterministicCase">
+    {#snippet template()}
+        {@const reels = [
+            ['A', 'K', 'Q'],
+            ['J', '10', '9', 'A'],
+            ['K', 'Q', 'J', '10'],
+            ['Q', 'J', '10', '9', 'A'],
+            ['9', 'A', 'K'],
+            ['10', '9', 'A', 'K'],
+        ]}
+        <div style="padding:16px;">
+            <VariableWaysGrid {reels} cellSize={80} reelGap={8} />
+        </div>
+    {/snippet}
+</Story>

--- a/web-sdk/packages/variable-ways/package.json
+++ b/web-sdk/packages/variable-ways/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@stake/variable-ways",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "svelte": "./src/lib/VariableWaysGrid.svelte",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "@stake/math-sdk": "*"
+  },
+  "scripts": {
+    "build": "echo \"variable-ways: nothing to build\""
+  }
+}

--- a/web-sdk/packages/variable-ways/src/index.ts
+++ b/web-sdk/packages/variable-ways/src/index.ts
@@ -1,0 +1,3 @@
+export { default as VariableWaysGrid } from "./lib/VariableWaysGrid.svelte";
+export * from "./lib/VariableWaysGrid.svelte";
+export * from "./lib/spinMachine";

--- a/web-sdk/packages/variable-ways/src/lib/VariableWaysGrid.svelte
+++ b/web-sdk/packages/variable-ways/src/lib/VariableWaysGrid.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  export let reels: string[][] = [];
+  export let reelGap: number = 8;
+  export let maxRows: number = 7;
+  export let cellSize: number = 84;
+
+  const symbols = ['A', 'K', 'Q', 'J', '10', '9'];
+
+  function randomReels(count = 6) {
+    return Array.from({ length: count }, () => {
+      const rows = Math.floor(Math.random() * 4) + 3; // 3-6
+      return Array.from({ length: rows }, () => symbols[Math.floor(Math.random() * symbols.length)]);
+    });
+  }
+
+  if (!reels || reels.length === 0) {
+    reels = randomReels();
+  }
+</script>
+
+<div
+  class="grid"
+  style="--cellSize:{cellSize}px; --gap:{reelGap}px; --maxRows:{maxRows}; grid-template-columns:repeat({reels.length}, 1fr);"
+>
+  {#each reels as reel}
+    <div class="reel">
+      {#each reel as symbol}
+        <div class="cell">{symbol}</div>
+      {/each}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .grid {
+    display: grid;
+    column-gap: var(--gap);
+    height: calc(var(--cellSize) * var(--maxRows) + var(--gap) * (var(--maxRows) - 1));
+    padding: var(--gap);
+    background: #f9f9f9;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+  }
+  .reel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap);
+    align-items: center;
+  }
+  .cell {
+    width: var(--cellSize);
+    height: var(--cellSize);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: white;
+    font-family: sans-serif;
+    font-size: 1.25rem;
+    color: #333;
+    transition: background 0.2s;
+  }
+  .cell:hover {
+    background: #f0f0f0;
+  }
+</style>

--- a/web-sdk/packages/variable-ways/src/lib/spinMachine.ts
+++ b/web-sdk/packages/variable-ways/src/lib/spinMachine.ts
@@ -1,0 +1,63 @@
+import { writable, get } from 'svelte/store';
+import { evaluateVariableWays } from '@stake/math-sdk';
+
+const symbols = ['A', 'K', 'Q', 'J', '10', '9'];
+
+function generateReels(count = 6, minRows = 3, maxRows = 6): string[][] {
+  return Array.from({ length: count }, () => {
+    const rows = Math.floor(Math.random() * (maxRows - minRows + 1)) + minRows;
+    return Array.from({ length: rows }, () => symbols[Math.floor(Math.random() * symbols.length)]);
+  });
+}
+
+function evaluateWays(reels: string[][]) {
+  const board = reels.map((reel) => reel.map((symbol) => ({ symbol })));
+  const result = evaluateVariableWays({ board } as any);
+  return {
+    totalWin: result.totalWin ?? 0,
+    wins: (result.wins ?? []).map((w: any) => ({
+      symbol: w.symbol,
+      count: w.count,
+      payout: w.payout,
+    })),
+  };
+}
+
+export type SpinState = 'Idle' | 'Spinning' | 'Evaluating' | 'ShowingWin';
+
+export interface WinDetail {
+  symbol: string;
+  count: number;
+  payout: number;
+}
+
+export interface SpinMachineState {
+  state: SpinState;
+  reels: string[][];
+  lastWin: { totalWin: number; wins: WinDetail[] };
+}
+
+const initialReels = generateReels();
+
+export const spinStore = writable<SpinMachineState>({
+  state: 'Idle',
+  reels: initialReels,
+  lastWin: { totalWin: 0, wins: [] }
+});
+
+export async function spin() {
+  spinStore.update(() => ({
+    state: 'Spinning',
+    reels: generateReels(),
+    lastWin: { totalWin: 0, wins: [] }
+  }));
+  await new Promise((resolve) => setTimeout(resolve, 900));
+  spinStore.update((s) => ({ ...s, state: 'Evaluating' }));
+}
+
+export async function finishEvaluation(win?: { totalWin: number; wins: WinDetail[] }) {
+  const result = win ?? evaluateWays(get(spinStore).reels);
+  spinStore.update((s) => ({ ...s, state: 'ShowingWin', lastWin: result }));
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  spinStore.update((s) => ({ ...s, state: 'Idle' }));
+}


### PR DESCRIPTION
## Summary
- evaluate spins through @stake/math-sdk to derive real wins
- show win totals and breakdown in dev route using math-sdk results
- document math-sdk-backed evaluation in VariableWaysGrid story

## Testing
- `pnpm --filter @stake/variable-ways build`
- `pnpm --filter lines build` *(fails: tsconfig should extend SvelteKit config; pixi-svelte unresolved)*

------
https://chatgpt.com/codex/tasks/task_e_689d038a4878832fb97c8481affc6b94